### PR TITLE
Update screenshot.js

### DIFF
--- a/FMLab/TaskRecorderScreenshot/screenshot.js
+++ b/FMLab/TaskRecorderScreenshot/screenshot.js
@@ -11,7 +11,8 @@ document.addEventListener("screenshot", function() {
 			canvas.width = window.innerWidth * ratio;
 			canvas.height = window.innerHeight * ratio;
 			var taskRecorderPaneWidth = document.getElementById('asidePane').clientWidth * ratio;
-			context.drawImage(image, 0, 0, (canvas.width - taskRecorderPaneWidth), canvas.height, 0, 0, canvas.width, canvas.height);
+			var TaskRecorderToolbarHeight = document.getElementById('TaskRecorderToolbar').clientHeight * ratio;
+			context.drawImage(image, 0, TaskRecorderToolbarHeight, (canvas.width - taskRecorderPaneWidth), canvas.height, 0, 0, canvas.width - taskRecorderPaneWidth, canvas.height - TaskRecorderToolbarHeight);
 			var croppedImage = canvas.toDataURL('image/png');
 
 			var origin = window.location.protocol + "//" + window.location.host;


### PR DESCRIPTION
Fix issue with screenshot being clipped to exclude task recorder pane, but output at original width, resulting in stretched and blurry screenshot
Clip screenshot to exclude the task recorder toolbar at top of screen